### PR TITLE
Integrate LoRA into SAM2 training

### DIFF
--- a/func_3d/utils.py
+++ b/func_3d/utils.py
@@ -19,7 +19,7 @@ import cfg
 args = cfg.parse_args()
 device = torch.device('cuda', args.gpu_device)
 
-def get_network(args, net, use_gpu=True, gpu_device = 0, distribution = True):
+def get_network(args, net, use_gpu=True, gpu_device = 0, distribution = True, use_lora: bool = False):
     """ return given network
     """
 
@@ -29,7 +29,7 @@ def get_network(args, net, use_gpu=True, gpu_device = 0, distribution = True):
         sam2_checkpoint = args.sam_ckpt
         model_cfg = args.sam_config
 
-        net = build_sam2_video_predictor(config_file=model_cfg, ckpt_path=sam2_checkpoint, mode=None)
+        net = build_sam2_video_predictor(config_file=model_cfg, ckpt_path=sam2_checkpoint, mode=None, use_lora=use_lora)
     else:
         print('the network name you have entered is not supported yet')
         sys.exit()

--- a/sam2_train/build_sam.py
+++ b/sam2_train/build_sam.py
@@ -19,6 +19,7 @@ def build_sam2(
     mode="eval",
     hydra_overrides_extra=[],
     apply_postprocessing=True,
+    use_lora: bool = False,
 ):
 
     if apply_postprocessing:
@@ -31,6 +32,9 @@ def build_sam2(
         ]
     # Read config and init model
     cfg = compose(config_name=config_file, overrides=hydra_overrides_extra)
+    if use_lora:
+        cfg.model.image_encoder.use_lora = True
+        cfg.model.image_encoder.trunk.use_lora = True
     OmegaConf.resolve(cfg)
     model = instantiate(cfg.model, _recursive_=True)
     _load_checkpoint(model, ckpt_path)
@@ -47,6 +51,7 @@ def build_sam2_video_predictor(
     mode="eval",
     hydra_overrides_extra=[],
     apply_postprocessing=True,
+    use_lora: bool = False,
 ):
     hydra_overrides = [
         "++model._target_=sam2_train.sam2_video_predictor.SAM2VideoPredictor",
@@ -67,6 +72,9 @@ def build_sam2_video_predictor(
 
     # Read config and init model
     cfg = compose(config_name=config_file, overrides=hydra_overrides)
+    if use_lora:
+        cfg.model.image_encoder.use_lora = True
+        cfg.model.image_encoder.trunk.use_lora = True
     OmegaConf.resolve(cfg)
     model = instantiate(cfg.model, _recursive_=True)
     _load_checkpoint(model, ckpt_path)

--- a/sam2_train/modeling/backbones/hiera_lora_block.py
+++ b/sam2_train/modeling/backbones/hiera_lora_block.py
@@ -1,0 +1,74 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from sam_models.common.loralib import layers as lora
+
+
+def do_pool(x: torch.Tensor, pool: nn.Module, norm: nn.Module = None) -> torch.Tensor:
+    if pool is None:
+        return x
+    x = x.permute(0, 3, 1, 2)
+    x = pool(x)
+    x = x.permute(0, 2, 3, 1)
+    if norm:
+        x = norm(x)
+    return x
+
+
+class LoraAttention(nn.Module):
+    def __init__(self, dim: int, dim_out: int, num_heads: int, q_pool: nn.Module = None, r: int = 4, lora_alpha: int = 1) -> None:
+        super().__init__()
+        self.dim = dim
+        self.dim_out = dim_out
+        self.num_heads = num_heads
+        head_dim = dim_out // num_heads
+        self.scale = head_dim ** -0.5
+        self.q_pool = q_pool
+        self.qkv = lora.MergedLinear(
+            dim,
+            dim_out * 3,
+            r=r,
+            lora_alpha=lora_alpha,
+            lora_dropout=0.1,
+            enable_lora=[True, True, True],
+            fan_in_fan_out=True,
+            merge_weights=False,
+            bias=True,
+        )
+        self.proj = nn.Linear(dim_out, dim_out)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        B, H, W, _ = x.shape
+        qkv = self.qkv(x).reshape(B, H * W, 3, self.num_heads, -1)
+        q, k, v = torch.unbind(qkv, 2)
+        if self.q_pool is not None:
+            q = do_pool(q.reshape(B, H, W, -1), self.q_pool)
+            H, W = q.shape[1:3]
+            q = q.reshape(B, H * W, self.num_heads, -1)
+        attn = F.scaled_dot_product_attention(
+            q.transpose(1, 2),
+            k.transpose(1, 2),
+            v.transpose(1, 2),
+        )
+        x = attn.transpose(1, 2).reshape(B, H, W, -1)
+        x = self.proj(x)
+        return x
+
+
+class LoraMLP(nn.Module):
+    def __init__(self, in_features: int, hidden_features: int = None, out_features: int = None, act_layer=nn.GELU, drop: float = 0.0, r: int = 4, lora_alpha: int = 1) -> None:
+        super().__init__()
+        out_features = out_features or in_features
+        hidden_features = hidden_features or in_features
+        self.fc1 = lora.Linear(in_features, hidden_features, r=r, lora_alpha=lora_alpha)
+        self.act = act_layer()
+        self.fc2 = lora.Linear(hidden_features, out_features, r=r, lora_alpha=lora_alpha)
+        self.drop = nn.Dropout(drop)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.fc1(x)
+        x = self.act(x)
+        x = self.drop(x)
+        x = self.fc2(x)
+        x = self.drop(x)
+        return x

--- a/sam2_train/modeling/backbones/image_encoder.py
+++ b/sam2_train/modeling/backbones/image_encoder.py
@@ -17,6 +17,7 @@ class ImageEncoder(nn.Module):
         trunk: nn.Module,
         neck: nn.Module,
         scalp: int = 0,
+        use_lora: bool = False,
     ):
         super().__init__()
         self.trunk = trunk


### PR DESCRIPTION
## Summary
- create `hiera_lora_block.py` with LoRA attention and MLP
- allow `MultiScaleBlock` and `Hiera` backbone to use LoRA
- propagate `use_lora` flag through image encoder and build helpers
- update `get_network` and training script for LoRA fine‑tuning

## Testing
- `python -m py_compile $(git ls-files '*.py' | grep -v 'adapter_block.py' | grep -v 'sam_models/common/loralib/utils.py')`

------
https://chatgpt.com/codex/tasks/task_e_684b7cad65688326949b712bb61ff016